### PR TITLE
Remove `typed` from templates

### DIFF
--- a/nimquery.nim
+++ b/nimquery.nim
@@ -136,7 +136,7 @@ const CombinatorKinds = {
     tkCombinatorNextSibling, tkCombinatorSiblings
 }
 
-template log(msg: string): typed =
+template log(msg: string) =
     when DEBUG:
         echo msg
 
@@ -803,7 +803,7 @@ proc exec(parts: seq[QueryPart],
     var partIndex = 0
     buffer.addLast root
 
-    template search(position: NodeWithParent, itr: SearchIterator): typed =
+    template search(position: NodeWithParent, itr: SearchIterator) =
         for next in itr(parts[partIndex], position):
             if partIndex == high(parts):
                 result.add next.node

--- a/nimquery.nimble
+++ b/nimquery.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.2.1"
+version       = "1.2.2"
 author        = "Oscar Nihlgård"
 description   = "Library for querying HTML using CSS-selectors (like JavaScripts document.querySelector)"
 license       = "MIT"


### PR DESCRIPTION
Fixes this warning when running tests:
```
Warning: `typed` will change its meaning in future versions of Nim. `void` or no return type declaration at all has the same meaning as the current meaning of `typed` as return type declaration. [Deprecated]
```
Also bumped the version number.