### PR TITLE
fix for RFC/294 ; disallow enum <=> enum conversion

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Nim environment
-      uses: jiro4989/setup-nim-action@v1.0.2
+      uses: jiro4989/setup-nim-action@v1
       with:
         nim-version: ${{ matrix.nim }}
 

--- a/nimquery.nim
+++ b/nimquery.nim
@@ -912,7 +912,7 @@ proc parseHtmlQuery*(queryString: string,
                 else: doAssert(false) # can't happen
 
             of CombinatorKinds:
-                parts.add initQueryPart(demands, lexer.current.kind.Combinator)
+                parts.add initQueryPart(demands, lexer.current.kind.ord.Combinator)
                 demands = @[]
 
             of tkComma:


### PR DESCRIPTION
/cc @GULPF 
fix to unblock https://github.com/nim-lang/Nim/pull/16351 for accepted nim RFC https://github.com/nim-lang/RFCs/issues/294

(that's the only blocker for the PR)

CI failure unrelated IIUC, and should be fixed :) 